### PR TITLE
adding shape algebras for cofolding

### DIFF
--- a/Algebras/Shapes/alg_shapes_rope.gap
+++ b/Algebras/Shapes/alg_shapes_rope.gap
@@ -1,299 +1,88 @@
-algebra alg_shapeX implements sig_foldrna(alphabet = char, answer = Rope) {
-  Rope sadd(Subsequence b, Rope x) {
-    Rope emptyShape;
-    
-    if (x == emptyShape) {
-		Rope res;
-		append(res, '_');
-      return res;
-    } else {
-	  if ((shapelevel() == 1) && (front(x) != '_')) {
-		Rope res;
-		append(res, '_');
-		append(res, x);
-		return res;
-	  } else {
-		return x;
-	  }
-    }
-  }
-
-  Rope cadd(Rope le,Rope re) {
-	if (shapelevel() == 1) {
-		if (back(le) == '_' && front(re) == '_') {
-		  return le + tail(re);
-		} else {
-		  return le + re;
-		}
-	} else {
-		if (re == "_") {
-		  return le;
-		} else {
-		  return le + re;
-		}			
-	}
-  }
-
-  Rope cadd_Pr(Rope le,Rope re) {
-    return le + re;
-  }
-
-  Rope cadd_Pr_Pr(Rope le,Rope re) {
-	if (shapelevel() == 1) {
-		return le + tail(re);
-	} else {
-		if (re == "_") {
-		  return le;
-		} else {
-		  return le + re;
-		}
-	}
-  }
-
-  Rope cadd_Pr_Pr_Pr(Rope le,Rope re) {
-    return le + re;
-  }
-
-  Rope ambd(Rope le,Subsequence b,Rope re) {
-	Rope res;
-	append(res, le);
-	if (shapelevel() == 1) { append(res, '_'); }
-	append(res, re);
-	return res;
-  }
-
-  Rope ambd_Pr(Rope le,Subsequence b,Rope re) {
-	Rope res;
-	append(res, le);
-	if (shapelevel() == 1) { append(res, '_'); }
-	append(res, re);
-	return res;
-  }
-
-  Rope nil(Subsequence loc) {
-    Rope r;
-    return r;
-  }
-
-  Rope edl(Subsequence lb,Rope e, Subsequence rloc) {
-	if (shapelevel() == 1) {
-		Rope res;
-		append(res, '_');
-		append(res, e);
-		return res;
-	} else {
-		return e;
-	}
-  }
-
-  Rope edr(Subsequence lloc, Rope e,Subsequence rb) {
-	if (shapelevel() == 1) {
-		Rope res = e;
-		append(res, '_');
-		return res;
-	} else {
-		return e;
-	}
-  }
-
-  Rope edlr(Subsequence lb,Rope e,Subsequence rb) {
-	if (shapelevel() == 1) {
-		Rope res;
-		append(res, '_');
-		append(res, e);
-		append(res, '_');
-		return res;
-	} else {
-		return e;
-	}
-  }
-
-  Rope drem(Subsequence lloc, Rope e, Subsequence rloc) {
-    return e;
-  }
-
-  Rope dall(Subsequence lloc, Rope e, Subsequence rloc) {
-    return e;
-  }
-
-  Rope sr(Subsequence lb,Rope e,Subsequence rb) {
-    return e;
-  }
-
-  Rope hl(Subsequence lb,Subsequence region,Subsequence rb) {
-	  Rope res;
-	  append(res, "[]");
-	  return res;
-  }
-
-
-  Rope bl(Subsequence lb,Subsequence lregion,Rope x,Subsequence rb) {
-	if (shapelevel() <= 3) {
-		Rope res;
-		append(res, '[');
-		if (shapelevel() <= 2) { append(res, '_'); }
-		append(res, x);
-		append(res, ']');
-		return res;
-	} else {
-		return x;
-	}
-  }
-
-  Rope br(Subsequence lb,Rope x,Subsequence rregion,Subsequence rb) {
-	if (shapelevel() <= 3) {
-		Rope res;
-		append(res, '[');
-		append(res, x);
-		if (shapelevel() <= 2) { append(res, '_'); }
-		append(res, ']');
-		return res;
-	} else {
-		return x;
-	}
-  }
-
-  Rope il(Subsequence lb,Subsequence lregion,Rope x,Subsequence rregion,Subsequence rb) {
-	if (shapelevel() <= 4) {
-		Rope res;
-		append(res, '[');
-		if (shapelevel() <= 2) { append(res, '_'); }
-		append(res, x);
-		if (shapelevel() <= 2) { append(res, '_'); }
-		append(res, ']');
-		return res;
-	} else {
-		return x;
-	}
-  }
-
-  Rope ml(Subsequence lb,Rope e,Subsequence rb) {
-    return '[' + e + ']';
-  }
-
-  Rope mlall(Subsequence lb,Rope e,Subsequence rb) {
-    return '[' + e + ']';
-  }
-
-  Rope mldr(Subsequence lb,Rope e,Subsequence dr,Subsequence rb) {
-	  Rope res;
-	  append(res, '[');
-	  append(res, e);
-	  if ((shapelevel() == 1) && (back(e) != '_')) { append(res, '_'); }
-	  append(res, ']');
-	  return res;
-  }
-
-  Rope mladr(Subsequence lb,Rope e,Subsequence dr,Subsequence rb) {
-	  Rope res;
-	  append(res, '[');
-	  append(res, e);
-	  if (shapelevel() == 1) { append(res, '_'); }
-	  append(res, ']');
-	  return res;
-  }
-
-  Rope mldlr(Subsequence lb,Subsequence dl,Rope e,Subsequence dr,Subsequence rb) {
-	  Rope res;
-	  append(res, '[');
-	  if ((shapelevel() == 1) && (front(e) != '_')) { append(res, '_'); }
-	  append(res, e);
-	  if ((shapelevel() == 1) && (back(e) != '_')) { append(res, '_'); }
-	  append(res, ']');
-	  return res;
-	  
-  }
-
-  Rope mladlr(Subsequence lb,Subsequence dl,Rope e,Subsequence dr,Subsequence rb) {
-	  Rope res;
-	  append(res, '[');
-	  if (shapelevel() == 1) { append(res, '_'); }
-	  append(res, e);
-	  if (shapelevel() == 1) { append(res, '_'); }
-	  append(res, ']');
-	  return res;
-  }
-
-  Rope mldladr(Subsequence lb,Subsequence dl,Rope e,Subsequence dr,Subsequence rb) {
-	  Rope res;
-	  append(res, '[');
-	  append(res, e);
-	  if (shapelevel() == 1) { append(res, '_'); }
-	  append(res, ']');
-	  return res;
-  }
-
-  Rope mladldr(Subsequence lb,Subsequence dl,Rope e,Subsequence dr,Subsequence rb) {
-	  Rope res;
-	  append(res, '[');
-	  if (shapelevel() == 1) { append(res, '_'); }
-	  append(res, e);
-	  append(res, ']');
-	  return res;
-  }
-
-  Rope mldl(Subsequence lb,Subsequence dl,Rope e,Subsequence rb) {
-	  Rope res;
-	  append(res, '[');
-	  if ((shapelevel() == 1) && (front(e) != '_')) { append(res, '_'); }
-	  append(res, e);
-	  append(res, ']');
-	  return res;
-  }
-
-  Rope mladl(Subsequence lb,Subsequence dl,Rope e,Subsequence rb) {
-	  Rope res;
-	  append(res, '[');
-	  if (shapelevel() == 1) { append(res, '_'); }
-	  append(res, e);
-	  append(res, ']');
-	  return res;
-  }
-
-  Rope addss(Rope x,Subsequence rb) {
-	Rope res;
-	append(res, x);
-	if ((shapelevel() == 1) && (back(x) != '_')) { append(res, '_'); }
-	return res;
-  }
-
-  Rope ssadd(Subsequence lb,Rope e) {
-    return e;
-  }
-
-  Rope trafo(Rope e) {
-    return e;
-  }
-
-  Rope incl(Rope e) {
-    return e;
-  }
-
-  Rope combine(Rope le,Rope re) {
-	if ((shapelevel() == 1) && (back(le) == '_') && (front(re) == '_')) {
-		return le + tail(re);
-    } else {
-		return le + re;
-    }
-  }
-
-  Rope acomb(Rope le,Subsequence b,Rope re) {
-	Rope res;
-	append(res, le);
-	if (shapelevel() == 1) { append(res, '_'); }
-	append(res, re);
-	return res;
-  }
-
-  choice [Rope] h([Rope] i) {
-    return unique(i);
-  }
-}
-
 algebra alg_shape5 implements sig_foldrna(alphabet = char, answer = Rope) {
+  Rope sadd_cut(Subsequence b, Subsequence cut, Rope e) {
+    Rope res;
+    append(res, '_');
+    append(res, '+');
+    append(res, e);
+    return res;
+  }
+  Rope cadd_cut(Rope le, Subsequence cut, Rope re) {
+    Rope res;
+    append(res, le);
+    append(res, '+');
+    append(res, re);
+    return res;
+  }
+  Rope hl_cut(Subsequence lb, Rope cut, Subsequence rb) {
+    Rope res;
+    append(res, '[');
+    append(res, cut);
+    append(res, ']');
+    return res;
+  }
+  Rope bl_cut(Subsequence lb, Rope cut, Rope e, Subsequence rb) {
+    Rope res;
+    append(res, '[');
+    append(res, cut);
+    append(res, e);
+    append(res, ']');
+    return res;
+  }
+  Rope br_cut(Subsequence lb, Rope e, Rope cut, Subsequence rb) {
+    Rope res;
+    append(res, '[');
+    append(res, e);
+    append(res, cut);
+    append(res, ']');
+    return res;
+  }
+  Rope il_cut_l(Subsequence lb, Rope cut, Rope e, Subsequence rregion, Subsequence rb) {
+    Rope res;
+    append(res, '[');
+    append(res, cut);
+    append(res, e);
+    append(res, '_');
+    append(res, ']');
+    return res;
+  }
+  Rope il_cut_r(Subsequence lb, Subsequence lregion, Rope e, Rope cut, Subsequence rb) {
+    Rope res;
+    append(res, '[');
+    append(res, '_');
+    append(res, e);
+    append(res, cut);
+    append(res, ']');
+    return res;
+  }
+  Rope cut(Subsequence lregion, Subsequence cut, Subsequence rregion) {
+    Rope res;
+    if (lregion.i < lregion.j) {
+      append(res, '_');
+    }
+    append(res, '+');
+    if (rregion.i < rregion.j) {
+      append(res, '_');
+    }
+    return res;
+  }
+  Rope ml_cut_l(Subsequence lb, Subsequence cut, Rope e, Subsequence rb) {
+    Rope res;
+    append(res, '[');
+    append(res, '+');
+    append(res, e);
+    append(res, ']');
+    return res;
+  }
+  Rope addss_cut(Rope e, Rope cut) {
+    Rope res;
+    append(res, e);
+    append(res, cut);
+    return res;
+  }
+
   Rope sadd(Subsequence b, Rope e) {
     Rope emptyShape;
-    
+
     if (e == emptyShape) {
       Rope res;
       append(res, '_');
@@ -371,6 +160,10 @@ algebra alg_shape5 implements sig_foldrna(alphabet = char, answer = Rope) {
     return e;
   }
 
+  Rope dall(Subsequence lb,Rope e,Subsequence rb) {
+    return e;
+  }
+
   Rope drem(Subsequence lloc, Rope e, Subsequence rloc) {
     return e;
   }
@@ -399,6 +192,14 @@ algebra alg_shape5 implements sig_foldrna(alphabet = char, answer = Rope) {
   }
 
   Rope ml(Subsequence lb,Rope e,Subsequence rb) {
+	  Rope res;
+	  append(res, '[');
+	  append(res, e);
+	  append(res, ']');
+    return res;
+  }
+
+  Rope mlall(Subsequence lb,Rope e,Subsequence rb) {
 	  Rope res;
 	  append(res, '[');
 	  append(res, e);
@@ -531,7 +332,7 @@ algebra alg_shape3 extends alg_shape5 {
 	  append(res, ']');
     return res;
   }
-  
+
   Rope il(Subsequence lb,Subsequence lregion,Rope e,Subsequence rregion,Subsequence rb) {
 	  Rope res;
 	  append(res, '[');
@@ -573,26 +374,26 @@ algebra alg_shape2 extends alg_shape5 {
 
 algebra alg_shape1 extends alg_shape5 {
   Rope sadd(Subsequence b, Rope e) {
-    if (front(e) == "_") {
+    if (front(e) == '_') {
       return e;
     } else {
-		Rope res;
-		append(res, '_');
-		append(res, e);
+		  Rope res;
+		  append(res, '_');
+		  append(res, e);
       return res;
     }
   }
 
   Rope cadd(Rope x, Rope y) {
-    if (back(x) == "_" && front(y) == "_") {
-		Rope res;
-		append(res, x);
-		append(res, tail(y));
+    if (back(x) == '_' && front(y) == '_') {
+		  Rope res;
+		  append(res, x);
+		  append(res, tail(y));
       return res;
     } else {
-		Rope res;
-		append(res, x);
-		append(res, y);
+	  	Rope res;
+	  	append(res, x);
+	  	append(res, y);
       return res; //not possible in macrostates, because there y has always a at least a single unpaired base at its left
     }
   }
@@ -750,7 +551,7 @@ algebra alg_shape1 extends alg_shape5 {
     append(res, ']');
     return res;
   }
-  
+
   Rope combine(Rope le,Rope re) {
     Rope res;
     append(res, le);
@@ -769,9 +570,9 @@ algebra alg_shape1 extends alg_shape5 {
     append(res, re);
     return res;
   }
-  
+
   Rope addss(Rope x,Subsequence rb) {
-    if (back(x) == "_") {
+    if (back(x) == '_') {
       return x;
     } else {
       Rope res;
@@ -782,4 +583,3 @@ algebra alg_shape1 extends alg_shape5 {
   }
 
 }
-

--- a/nodangle.gap
+++ b/nodangle.gap
@@ -15,7 +15,7 @@ type shape_t = shape
 
 include "Signatures/sig_foldrna.gap"
 include "Algebras/DotBracket/alg_dotBracket.gap"
-//include "Algebras/Shapes/alg_shapes.gap"
+include "Algebras/Shapes/alg_shapes_rope.gap"
 
 algebra alg_count auto count;
 algebra alg_enum auto enum;
@@ -40,7 +40,7 @@ include "Grammars/gra_nodangle.gap"
 //instance shape3mfepfxpp = gra_nodangle (((alg_shape3 * (alg_mfe % alg_pfunc)) suchthat filterLowProbShapes) * alg_dotBracket);  //must be compiled with --kbacktrace !
 //instance shape2mfepfxpp = gra_nodangle (((alg_shape2 * (alg_mfe % alg_pfunc)) suchthat filterLowProbShapes) * alg_dotBracket);  //must be compiled with --kbacktrace !
 //instance shape1mfepfxpp = gra_nodangle (((alg_shape1 * (alg_mfe % alg_pfunc)) suchthat filterLowProbShapes) * alg_dotBracket);  //must be compiled with --kbacktrace !
-                  
+
 //instance mfeshape5pp = gra_nodangle(alg_mfe * alg_shape5 * alg_dotBracket);
 //instance mfeshape4pp = gra_nodangle(alg_mfe * alg_shape4 * alg_dotBracket);
 //instance mfeshape3pp = gra_nodangle(alg_mfe * alg_shape3 * alg_dotBracket);


### PR DESCRIPTION
dieser PR sollte Dir fünf neue Algebren zugänglich machen. Sie implementieren die RNAshapes idee http://dx.doi.org/10.1093/nar/gkh779 
Damit solltest Du Instanzen kompilieren können `gapc -p "alg_shape1 * alg_count" nodangle.gap` die Dir besser aufsplitten wie die Anzahl der Kandidaten verteilt ist.